### PR TITLE
feat: add DisplayMessageDetails and DisplayGroupMemberRealName hooks

### DIFF
--- a/app/src/main/java/dev/ujhhgtg/wekit/hooks/items/chat/DisplayMessageDetails.kt
+++ b/app/src/main/java/dev/ujhhgtg/wekit/hooks/items/chat/DisplayMessageDetails.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import dev.ujhhgtg.wekit.hooks.api.ui.WeChatMessageContextMenuApi
 import dev.ujhhgtg.wekit.hooks.core.HookItem
 import dev.ujhhgtg.wekit.hooks.core.SwitchHookItem
+import dev.ujhhgtg.wekit.hooks.items.contacts.DisplayGroupMemberRealName
 import dev.ujhhgtg.wekit.ui.content.AlertDialogContent
 import dev.ujhhgtg.wekit.ui.content.Button
 import dev.ujhhgtg.wekit.ui.utils.ChatInfoIcon
@@ -43,6 +45,42 @@ object DisplayMessageDetails : SwitchHookItem(),
                 displayItems += "对方/群聊 ID" to msgInfo.talker
                 displayItems += "真实发送者 ID" to msgInfo.sender
                 displayItems += "内容" to msgInfo.content
+                val realNameItem = mutableStateOf<Pair<String, String>?>(null)
+                val realNameTarget = when {
+                    msgInfo.isInGroupChat && !msgInfo.isSelfSender -> {
+                        DisplayGroupMemberRealName.parseGroupSender(msgInfo.content)
+                            ?.let { RealNameTarget("发送者实名", it, msgInfo.talker) }
+                    }
+
+                    !msgInfo.isInGroupChat &&
+                            !msgInfo.isOfficialAccount -> {
+                        RealNameTarget("好友实名", msgInfo.talker, "")
+                    }
+
+                    else -> null
+                }
+                if (realNameTarget != null) {
+                    val cachedName = DisplayGroupMemberRealName.getCachedDisplayName(
+                        realNameTarget.wxId
+                    )
+                    realNameItem.value = realNameTarget.title to when {
+                        cachedName != null -> DisplayGroupMemberRealName.formatDisplayName(cachedName)
+                        DisplayGroupMemberRealName.hasEnabled -> "查询中"
+                        else -> "实名显示未启用"
+                    }
+                    if (cachedName == null && DisplayGroupMemberRealName.hasEnabled) {
+                        val requested = DisplayGroupMemberRealName.requestDisplayName(
+                            realNameTarget.wxId,
+                            realNameTarget.chatroomId
+                        ) { displayName ->
+                            realNameItem.value = realNameTarget.title to DisplayGroupMemberRealName
+                                .formatDisplayName(displayName)
+                        }
+                        if (!requested) {
+                            realNameItem.value = realNameTarget.title to "查询失败"
+                        }
+                    }
+                }
 
                 showComposeDialog(view.context) {
                     AlertDialogContent(
@@ -53,7 +91,7 @@ object DisplayMessageDetails : SwitchHookItem(),
                                     .fillMaxWidth()
                                     .clip(MaterialTheme.shapes.large)
                             ) {
-                                items(displayItems) { (key, value) ->
+                                items(displayItems + listOfNotNull(realNameItem.value)) { (key, value) ->
                                     ListItem(
                                         headlineContent = { Text(key) },
                                         supportingContent = { Text(value) },
@@ -69,4 +107,10 @@ object DisplayMessageDetails : SwitchHookItem(),
             }
         )
     }
+
+    private data class RealNameTarget(
+        val title: String,
+        val wxId: String,
+        val chatroomId: String
+    )
 }

--- a/app/src/main/java/dev/ujhhgtg/wekit/hooks/items/contacts/DisplayGroupMemberRealName.kt
+++ b/app/src/main/java/dev/ujhhgtg/wekit/hooks/items/contacts/DisplayGroupMemberRealName.kt
@@ -1,0 +1,118 @@
+package dev.ujhhgtg.wekit.hooks.items.contacts
+
+import android.os.Handler
+import android.os.Looper
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedBridge
+import de.robv.android.xposed.XposedHelpers
+import dev.ujhhgtg.wekit.hooks.api.net.WeNetSceneApi
+import dev.ujhhgtg.wekit.hooks.core.HookItem
+import dev.ujhhgtg.wekit.hooks.core.SwitchHookItem
+import dev.ujhhgtg.wekit.preferences.WePrefs
+import dev.ujhhgtg.wekit.preferences.WePrefs.Companion.prefOption
+import dev.ujhhgtg.wekit.utils.WeLogger
+import dev.ujhhgtg.wekit.utils.reflection.ClassLoaders
+import java.util.Collections
+import java.util.WeakHashMap
+
+@HookItem(name = "显示群成员实名", categories = ["联系人与群组"], description = "查询并缓存群聊成员实名, 可在消息详情中显示")
+object DisplayGroupMemberRealName : SwitchHookItem() {
+
+    private const val TAG = "DisplayGroupMemberRealName"
+    private const val REQUEST_CLASS_NAME = "com.tencent.mm.plugin.remittance.model.i"
+    private const val CALLBACK_METHOD_NAME = "I"
+    private const val RESPONSE_FIELD_NAME = "r"
+    private const val REAL_NAME_FIELD_NAME = "f"
+    private const val REAL_NAME_PREFIX_KEY = "key_real_name_prefix"
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val pendingRequests = Collections.synchronizedMap(
+        WeakHashMap<Any, PendingRealNameRequest>()
+    )
+
+    private var realNamePrefix by prefOption(REAL_NAME_PREFIX_KEY, "*")
+
+    override fun onEnable() {
+        val requestClass = XposedHelpers.findClassIfExists(REQUEST_CLASS_NAME, ClassLoaders.HOST)
+            ?: error("real name request class not found: $REQUEST_CLASS_NAME")
+
+        XposedBridge.hookAllMethods(
+            requestClass,
+            CALLBACK_METHOD_NAME,
+            object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    val request = param.thisObject ?: return
+                    val pending = pendingRequests.remove(request) ?: return
+                    val response = XposedHelpers.getObjectField(request, RESPONSE_FIELD_NAME)
+                        ?: return
+                    val fullName = XposedHelpers.getObjectField(
+                        response,
+                        REAL_NAME_FIELD_NAME
+                    ) as? String ?: return
+                    if (fullName.isEmpty()) return
+
+                    val displayName = maskRealName(fullName)
+                    cacheDisplayName(pending.wxId, displayName)
+                    mainHandler.post { pending.onResult(displayName) }
+                }
+            }
+        ).forEach(::registerUnhook)
+    }
+
+    fun getCachedDisplayName(wxId: String): String? {
+        return WePrefs.getStringOrDef(cacheKey(wxId), "").takeIf { it.isNotEmpty() }
+    }
+
+    fun requestDisplayName(
+        wxId: String,
+        chatroomId: String,
+        onResult: (String) -> Unit
+    ): Boolean {
+        if (!hasEnabled) return false
+        if (wxId.isBlank()) return false
+
+        getCachedDisplayName(wxId)?.let { cached ->
+            mainHandler.post { onResult(cached) }
+            return true
+        }
+
+        return runCatching {
+            val requestClass = XposedHelpers.findClassIfExists(REQUEST_CLASS_NAME, ClassLoaders.HOST)
+                ?: return@runCatching false
+            val request = XposedHelpers.newInstance(requestClass, wxId, chatroomId)
+                ?: return@runCatching false
+            pendingRequests[request] = PendingRealNameRequest(wxId, onResult)
+            WeNetSceneApi.addNetSceneToQueue(request)
+            true
+        }.onFailure {
+            WeLogger.w(TAG, "failed to request real name for $wxId", it)
+        }.getOrDefault(false)
+    }
+
+    fun parseGroupSender(content: String): String? {
+        val idx = content.indexOf(":\n")
+        if (idx <= 0) return null
+        val wxId = content.substring(0, idx).trim()
+        if (wxId.isEmpty() || wxId.contains("<")) return null
+        return wxId
+    }
+
+    fun formatDisplayName(displayName: String): String {
+        return "*$displayName"
+    }
+
+    private fun cacheDisplayName(wxId: String, displayName: String) {
+        WePrefs.putString(cacheKey(wxId), displayName)
+    }
+
+    private fun cacheKey(wxId: String) = "real_name_$wxId"
+
+    private fun maskRealName(fullName: String): String {
+        return realNamePrefix + fullName.last()
+    }
+
+    private data class PendingRealNameRequest(
+        val wxId: String,
+        val onResult: (String) -> Unit
+    )
+}


### PR DESCRIPTION
## 描述 / Description

在 消息详细里面添加 实名查看 
为什么不选择在好友/群聊里面的人 名字后面加[**X] 我觉得这样会卡。而且意义不大
效果最终一样

## 类型 / Type
- [ ] Bug 修复
- [x] 新功能
- [ ] 文档更新
- [ ] 其他

## 清单 / Checklist
- [x] 我已阅读并遵循贡献指南
- [x] 我已在本地测试这些更改
- [x] 我已更新相关文档或注释
- [x] 我确认此更改不会破坏任何原有功能
- [x] 我已在多个微信版本上测试此更改

### 合规性与原创性声明 / Compliance & Originality
- [ ] **如果参考了其他开源项目，我已在“其他信息”中明确标注来源及协议**

## 其他信息 / Additional Information
