### PR TITLE
外部页面滑动状态和底部栏内部选中状态互相触发，形成了反向滑动时的“反馈导航”

### DIFF
--- a/app/src/main/java/dev/ujhhgtg/wekit/ui/content/FloatingBottomBar.kt
+++ b/app/src/main/java/dev/ujhhgtg/wekit/ui/content/FloatingBottomBar.kt
@@ -75,7 +75,6 @@ import com.kyant.backdrop.shadow.Shadow
 import dev.ujhhgtg.wekit.ui.content.animation.DampedDragAnimation
 import dev.ujhhgtg.wekit.ui.content.animation.InteractiveHighlight
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.sign
@@ -218,8 +217,12 @@ fun FloatingBottomBar(
             onDragStarted = {},
             onDragStopped = {
                 val targetIndex = targetValue.fastRoundToInt().fastCoerceIn(0, tabsCount - 1)
-                currentIndex = targetIndex
+                val previousIndex = currentIndex
                 animateToValue(targetIndex.toFloat())
+                if (targetIndex != previousIndex) {
+                    currentIndex = targetIndex
+                    onSelected(targetIndex)
+                }
                 animationScope.launch {
                     offsetAnimation.animateTo(0f, spring(1f, 300f, 0.5f))
                 }
@@ -239,12 +242,9 @@ fun FloatingBottomBar(
     }
 
     LaunchedEffect(selectedIndex) {
-        snapshotFlow { selectedIndex() }.collectLatest { currentIndex = it }
-    }
-    LaunchedEffect(dampedDragAnimation) {
-        snapshotFlow { currentIndex }.drop(1).collectLatest { index ->
+        snapshotFlow { selectedIndex() }.collectLatest { index ->
+            currentIndex = index
             dampedDragAnimation.animateToValue(index.toFloat())
-            onSelected(index)
         }
     }
 


### PR DESCRIPTION
## 描述 / Description

修复启用「美化首页底部导航栏」后，从左往右滑动首页 Tab 时切换速度异常过快的问题。

原因是底部栏在接收到 ViewPager 滑动回调更新选中状态后，又反向触发了 `onSelected` 导航，导致手势滑动被程序切页打断。

## 类型 / Type

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

## 清单 / Checklist

- [x] 我已阅读并遵循贡献指南
- [ ] 我已在本地测试这些更改
- [ ] 我已更新相关文档或注释
- [x] 我确认此更改不会破坏任何原有功能
- [ ] 我已在多个微信版本上测试此更改

### 合规性与原创性声明 / Compliance & Originality

- [x] **如果参考了其他开源项目，我已在“其他信息”中明确标注来源及协议**

## 其他信息 / Additional Information

未参考其他开源项目。