### PR TITLE
Potential fix for code scanning alert no. 30: Cache Poisoning via code injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,12 +326,13 @@ jobs:
           MESSAGE_THREAD_ID: ${{ secrets.TELEGRAM_MESSAGE_THREAD_ID }}
           SHA:               ${{ github.sha }}
           COMMIT_AUTHOR:     ${{ github.event.head_commit.author.name || github.actor }}
+          COMMIT_MESSAGE:    ${{ github.event.head_commit.message || 'Manual Build' }}
           REPO:              ${{ github.repository }}
         run: |
           caption="🎉 *检测到新的 GitHub 推送！*
           *Commit SHA:* \`${SHA}\`
           \`\`\`
-          ${{ github.event.head_commit.message || 'Manual Build' }}
+          ${COMMIT_MESSAGE}
           \`\`\`
           *提交者* \`${COMMIT_AUTHOR}\`
           [查看详情](https://github.com/${REPO}/commit/${SHA})"


### PR DESCRIPTION
Potential fix for [https://github.com/Ujhhgtg/WeKit/security/code-scanning/30](https://github.com/Ujhhgtg/WeKit/security/code-scanning/30)

General fix: never splice untrusted GitHub context values directly into shell script source. Instead, pass them through `env:` and reference them as quoted shell variables (`"$VAR"`), so content is treated as data, not code.

Best fix here (without changing behavior): in `.github/workflows/ci.yml` within the “Send build artifacts via Telegram API” step, add a new environment variable for the commit message:
- `COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'Manual Build' }}`
Then replace the inline expression inside the heredoc-like caption assignment with `${COMMIT_MESSAGE}`. This preserves the same message fallback and output formatting while removing direct expression injection into the script body.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
